### PR TITLE
fix issue with tabs multi input

### DIFF
--- a/scripts/ui.py
+++ b/scripts/ui.py
@@ -15,7 +15,7 @@ def add_tab():
             with gr.Column(variant='panel'):
                 gr.HTML(value="<p>Converted checkpoints will be saved in your <b>checkpoint</b> directory.</p>")
                 with gr.Tabs():
-                    with gr.TabItem(label='Single process'):
+                    with gr.TabItem(label='Single process') as single_process:
                         with gr.Row():
                             model_name = gr.Dropdown(sd_models.checkpoint_tiles(),
                                                      elem_id="model_converter_model_name",
@@ -25,11 +25,11 @@ def add_tab():
                                                   "refresh_checkpoint_Z")
                         custom_name = gr.Textbox(label="Custom Name (Optional)")
 
-                    with gr.TabItem(label='Input file path'):
+                    with gr.TabItem(label='Input file path') as input_file_path:
                         with gr.Row():
                             model_path = gr.Textbox(label="model path")
 
-                    with gr.TabItem(label='Batch from directory'):
+                    with gr.TabItem(label='Batch from directory') as batch_from_directory:
                         with gr.Row():
                             input_directory = gr.Textbox(label="Input Directory")
 
@@ -63,6 +63,10 @@ def add_tab():
             with gr.Column(variant='panel'):
                 submit_result = gr.Textbox(elem_id="model_converter_result", show_label=False)
 
+            path_mode = gr.Number(value=0, visible=False)
+            for i, tab in enumerate([single_process, input_file_path, batch_from_directory]):
+                tab.select(fn=lambda tabnum=i: tabnum, inputs=[], outputs=[path_mode])
+
             show_extra_options.change(
                 fn=lambda x: gr_show(x),
                 inputs=[show_extra_options],
@@ -72,6 +76,7 @@ def add_tab():
             model_converter_convert.click(
                 fn=convert.convert_warp,
                 inputs=[
+                    path_mode,
                     model_name,
                     model_path,
                     input_directory,


### PR DESCRIPTION
the tabs `single process` `input file path` `batch from directory` is something I didn't weigh that the tab itself does not do anything

currently in order for a certain mode to be operate [only 1 in `[model_name, model_path, directory]`](https://github.com/Akegarasu/sd-webui-model-converter/blob/ae33f5cf687d5b15d1625886e162677c6d05237e/scripts/convert.py#L116-L118) can be populated else error

I re-implemented the tab so little tab is currently selected will be the one that is active

this also removes an issue
because the 
```py
model_name = gr.Dropdown(sd_models.checkpoint_tiles(), elem_id="model_converter_model_name", "refresh_checkpoint_Z")
```
`allow_custom_value` is `False` and since there's no ` ` blank value available for selection
as such once a model is selected it cannot be deselected,
this causes `input file path` and `batch from directory` mode to be unusable as `model_name` is will always be populated

this method of implementing tab selection can be seen in multiple places of webui such as [img2img tab](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/feee37d75f1b168768014e4634dcb156ee649c05/modules/ui.py#L535-L587)
essentially this create a invisible number input that will be changed when it tab is selected, this invisible number as input to the function call

---

this possibly fix this issue
- https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/15933